### PR TITLE
✨ feat(ui): add click-outside functionality to close modals

### DIFF
--- a/src/components/media/MediaBlock.vue
+++ b/src/components/media/MediaBlock.vue
@@ -81,6 +81,9 @@ const closeModal = () => {
                   Close</button>
               </div>
             </div>
+            <form method="dialog" class="modal-backdrop" @click="closeModal">
+              <button>close</button>
+            </form>
           </dialog>
         </template>
       </template>

--- a/src/components/news/NewsBlock.vue
+++ b/src/components/news/NewsBlock.vue
@@ -49,6 +49,9 @@ const closeModal = () => {
           Close</button>
       </div>
     </div>
+    <form method="dialog" class="modal-backdrop" @click="closeModal">
+      <button>close</button>
+    </form>
   </dialog>
 
 </template>


### PR DESCRIPTION
- Add modal-backdrop with click handler to NewsBlock.vue
- Add modal-backdrop with click handler to MediaBlock.vue
- Users can now close modals by clicking outside the content area
- Maintains existing close button functionality
- Uses DaisyUI's standard modal-backdrop pattern for consistency

🤖 Generated with [Claude Code](https://claude.ai/code)