### PR TITLE
Add social media sharing buttons to blog posts

### DIFF
--- a/src/components/blog/BlogPostPage.vue
+++ b/src/components/blog/BlogPostPage.vue
@@ -3,6 +3,7 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import Navbar from '@/components/nav/Navbar.vue'
 import Footer from '@/components/nav/Footer.vue'
+import SocialShareButtons from '@/components/blog/SocialShareButtons.vue'
 import { useBlogPosts } from '@/composables/useBlogPosts.js'
 
 const route = useRoute()
@@ -26,6 +27,7 @@ const post = computed(() => getPost(route.params.slug))
         <div class="prose max-w-none">
           <component :is="post.component" />
         </div>
+        <SocialShareButtons :title="post.title" :slug="post.slug" />
       </div>
       <div v-else class="text-center mt-16">
         <p class="text-xl text-gray-500">Post not found.</p>

--- a/src/components/blog/BlogPostPage.vue
+++ b/src/components/blog/BlogPostPage.vue
@@ -19,15 +19,15 @@ const post = computed(() => getPost(route.params.slug))
       <div v-if="post" class="mx-4 my-8">
         <router-link to="/blog" class="link text-sm mb-4 inline-block">&larr; Back to blog</router-link>
         <h1 class="text-4xl font-bold mt-2 mb-2">{{ post.title }}</h1>
-        <div class="flex items-center gap-3 mb-6">
+        <div class="flex items-center gap-3 mb-2">
           <span class="text-gray-400">{{ post.date }}</span>
           <span v-if="post.updated" class="text-gray-400">(Updated: {{ post.updated }})</span>
           <span v-for="tag in post.tags" :key="tag" class="badge badge-outline badge-sm">{{ tag }}</span>
         </div>
+        <SocialShareButtons :title="post.title" :slug="post.slug" />
         <div class="prose max-w-none">
           <component :is="post.component" />
         </div>
-        <SocialShareButtons :title="post.title" :slug="post.slug" />
       </div>
       <div v-else class="text-center mt-16">
         <p class="text-xl text-gray-500">Post not found.</p>

--- a/src/components/blog/SocialShareButtons.vue
+++ b/src/components/blog/SocialShareButtons.vue
@@ -24,7 +24,7 @@ const shareLinks = computed(() => [
   {
     name: 'LinkedIn',
     icon: { prefix: 'fab', icon: 'linkedin' },
-    href: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url.value)}`
+    href: `https://www.linkedin.com/shareArticle?mini=true&url=${encodeURIComponent(url.value)}&title=${encodeURIComponent(props.title)}`
   },
   {
     name: 'Email',

--- a/src/components/blog/SocialShareButtons.vue
+++ b/src/components/blog/SocialShareButtons.vue
@@ -1,0 +1,66 @@
+<script setup>
+import { ref, computed } from 'vue'
+
+const props = defineProps({
+  title: String,
+  slug: String
+})
+
+const copied = ref(false)
+
+const url = computed(() => window.location.origin + '/blog/' + props.slug)
+
+const shareLinks = computed(() => [
+  {
+    name: 'Twitter',
+    icon: { prefix: 'fab', icon: 'twitter' },
+    href: `https://twitter.com/intent/tweet?text=${encodeURIComponent(props.title)}&url=${encodeURIComponent(url.value)}`
+  },
+  {
+    name: 'Bluesky',
+    icon: { prefix: 'fab', icon: 'bluesky' },
+    href: `https://bsky.app/intent/compose?text=${encodeURIComponent(props.title + ' ' + url.value)}`
+  },
+  {
+    name: 'LinkedIn',
+    icon: { prefix: 'fab', icon: 'linkedin' },
+    href: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url.value)}`
+  },
+  {
+    name: 'Email',
+    icon: { prefix: 'fas', icon: 'envelope' },
+    href: `mailto:?subject=${encodeURIComponent(props.title)}&body=${encodeURIComponent(url.value)}`
+  }
+])
+
+async function copyLink() {
+  await navigator.clipboard.writeText(url.value)
+  copied.value = true
+  setTimeout(() => { copied.value = false }, 2000)
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-3 mt-6 pt-4 border-t border-base-300">
+    <span class="text-sm text-gray-400">Share:</span>
+    <a
+      v-for="link in shareLinks"
+      :key="link.name"
+      :href="link.href"
+      target="_blank"
+      rel="noopener noreferrer"
+      :title="'Share on ' + link.name"
+      class="text-primary hover:opacity-70 transition-opacity"
+    >
+      <font-awesome-icon :icon="[link.icon.prefix, link.icon.icon]" class="text-xl" />
+    </a>
+    <button
+      @click="copyLink"
+      :title="copied ? 'Copied!' : 'Copy link'"
+      class="text-primary hover:opacity-70 transition-opacity"
+    >
+      <font-awesome-icon :icon="['fas', 'link']" class="text-xl" />
+    </button>
+    <span v-if="copied" class="text-sm text-success">Copied!</span>
+  </div>
+</template>

--- a/src/components/blog/SocialShareButtons.vue
+++ b/src/components/blog/SocialShareButtons.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 
 const copied = ref(false)
 
-const url = computed(() => window.location.origin + '/blog/' + props.slug)
+const url = computed(() => 'https://kaichengyang.com/blog/' + props.slug)
 
 const shareLinks = computed(() => [
   {

--- a/src/components/blog/SocialShareButtons.vue
+++ b/src/components/blog/SocialShareButtons.vue
@@ -41,7 +41,7 @@ async function copyLink() {
 </script>
 
 <template>
-  <div class="flex items-center gap-3 mt-6 pt-4 border-t border-base-300">
+  <div class="flex items-center gap-3 mb-6">
     <span class="text-sm text-gray-400">Share:</span>
     <a
       v-for="link in shareLinks"

--- a/src/components/blog/SocialShareButtons.vue
+++ b/src/components/blog/SocialShareButtons.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 
 const copied = ref(false)
 
-const url = computed(() => 'https://kaichengyang.com/blog/' + props.slug)
+const url = computed(() => window.location.origin + '/blog/' + props.slug)
 
 const shareLinks = computed(() => [
   {


### PR DESCRIPTION
## Summary
- Add `SocialShareButtons.vue` component with Twitter/X, Bluesky, LinkedIn, Email, and Copy Link buttons
- Integrate below the title/date/tags row on each blog post page
- Uses existing FontAwesome icons and follows Bio.vue styling patterns

## Test plan
- [ ] Navigate to a blog post and verify sharing buttons appear under the title
- [ ] Click each share button and confirm the correct URL opens
- [ ] Test Copy Link and verify clipboard content + "Copied!" feedback
- [ ] Check mobile responsiveness

Ref: KEV-1572