### PR TITLE
feat: generate per-post OG meta tags for LinkedIn sharing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --open",
-    "build": "vite build && node scripts/generate-rss.mjs",
+    "build": "vite build && node scripts/generate-rss.mjs && node scripts/generate-blog-meta.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/scripts/generate-blog-meta.mjs
+++ b/scripts/generate-blog-meta.mjs
@@ -1,0 +1,106 @@
+import { readFileSync, writeFileSync, readdirSync, mkdirSync, existsSync } from 'fs';
+import { join, basename } from 'path';
+import { fileURLToPath } from 'url';
+import matter from 'gray-matter';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const rootDir = join(__dirname, '..');
+const blogDir = join(rootDir, 'src', 'content', 'blog');
+const distDir = join(rootDir, 'dist');
+
+const SITE_URL = 'https://kaichengyang.github.io';
+
+function extractExcerpt(content, maxLen = 160) {
+  const plain = content
+    .replace(/^#{1,6}\s+.*$/gm, '')
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    .replace(/\[([^\]]*)\]\(.*?\)/g, '$1')
+    .replace(/^[-*+]\s+/gm, '')
+    .replace(/[*_`~]+/g, '')
+    .replace(/\n{2,}/g, ' ')
+    .replace(/\n/g, ' ')
+    .trim();
+  if (plain.length <= maxLen) return plain;
+  return plain.slice(0, maxLen).replace(/\s+\S*$/, '') + '...';
+}
+
+// Read the built index.html as template
+const template = readFileSync(join(distDir, 'index.html'), 'utf-8');
+
+// Read and parse all published blog posts
+const files = readdirSync(blogDir).filter(f => f.endsWith('.md'));
+
+const posts = files
+  .map(file => {
+    const raw = readFileSync(join(blogDir, file), 'utf-8');
+    const { data, content } = matter(raw);
+    const slug = basename(file, '.md');
+    return { ...data, slug, content };
+  })
+  .filter(post => post.status === 'published');
+
+let count = 0;
+
+for (const post of posts) {
+  const postUrl = `${SITE_URL}/blog/${post.slug}`;
+  const description = post.excerpt || extractExcerpt(post.content);
+  const title = post.title;
+
+  let html = template;
+
+  // Replace <title>
+  html = html.replace(
+    /<title>.*?<\/title>/,
+    `<title>${title}</title>`
+  );
+
+  // Replace existing og:title
+  html = html.replace(
+    /<meta property="og:title" content=".*?" \/>/,
+    `<meta property="og:title" content="${title}" />`
+  );
+
+  // Replace existing og:description
+  html = html.replace(
+    /<meta property="og:description" content=".*?" \/>/,
+    `<meta property="og:description" content="${description}" />`
+  );
+
+  // Add og:url and og:type after og:description
+  const ogDescTag = `<meta property="og:description" content="${description}" />`;
+  html = html.replace(
+    ogDescTag,
+    `${ogDescTag}\n    <meta property="og:url" content="${postUrl}" />\n    <meta property="og:type" content="article" />`
+  );
+
+  // Add twitter:title and twitter:description after twitter:site
+  const twitterSiteTag = '<meta name="twitter:site" content="@yang3kc" />';
+  let twitterInsert = `\n    <meta name="twitter:title" content="${title}" />\n    <meta name="twitter:description" content="${description}" />`;
+
+  // Add image tags if post has an image
+  if (post.image) {
+    const imageUrl = `${SITE_URL}${post.image}`;
+    html = html.replace(
+      ogDescTag,
+      `${ogDescTag}\n    <meta property="og:image" content="${imageUrl}" />`
+    );
+    // Use summary_large_image for posts with images
+    html = html.replace(
+      /<meta name="twitter:card" content=".*?" \/>/,
+      `<meta name="twitter:card" content="summary_large_image" />`
+    );
+    twitterInsert += `\n    <meta name="twitter:image" content="${imageUrl}" />`;
+  }
+
+  html = html.replace(twitterSiteTag, `${twitterSiteTag}${twitterInsert}`);
+
+  // Write to dist/blog/<slug>/index.html
+  const outDir = join(distDir, 'blog', post.slug);
+  if (!existsSync(outDir)) {
+    mkdirSync(outDir, { recursive: true });
+  }
+  writeFileSync(join(outDir, 'index.html'), html, 'utf-8');
+  count++;
+}
+
+console.log(`Blog meta pages generated for ${count} post(s)`);

--- a/scripts/generate-blog-meta.mjs
+++ b/scripts/generate-blog-meta.mjs
@@ -24,6 +24,14 @@ function extractExcerpt(content, maxLen = 160) {
   return plain.slice(0, maxLen).replace(/\s+\S*$/, '') + '...';
 }
 
+function escapeHtml(str = '') {
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 // Read the built index.html as template
 const template = readFileSync(join(distDir, 'index.html'), 'utf-8');
 
@@ -45,29 +53,31 @@ for (const post of posts) {
   const postUrl = `${SITE_URL}/blog/${post.slug}`;
   const description = post.excerpt || extractExcerpt(post.content);
   const title = post.title;
+  const safeTitle = escapeHtml(title);
+  const safeDescription = escapeHtml(description);
 
   let html = template;
 
   // Replace <title>
   html = html.replace(
     /<title>.*?<\/title>/,
-    `<title>${title}</title>`
+    `<title>${safeTitle}</title>`
   );
 
   // Replace existing og:title
   html = html.replace(
     /<meta property="og:title" content=".*?" \/>/,
-    `<meta property="og:title" content="${title}" />`
+    `<meta property="og:title" content="${safeTitle}" />`
   );
 
   // Replace existing og:description
   html = html.replace(
     /<meta property="og:description" content=".*?" \/>/,
-    `<meta property="og:description" content="${description}" />`
+    `<meta property="og:description" content="${safeDescription}" />`
   );
 
   // Add og:url and og:type after og:description
-  const ogDescTag = `<meta property="og:description" content="${description}" />`;
+  const ogDescTag = `<meta property="og:description" content="${safeDescription}" />`;
   html = html.replace(
     ogDescTag,
     `${ogDescTag}\n    <meta property="og:url" content="${postUrl}" />\n    <meta property="og:type" content="article" />`
@@ -75,7 +85,7 @@ for (const post of posts) {
 
   // Add twitter:title and twitter:description after twitter:site
   const twitterSiteTag = '<meta name="twitter:site" content="@yang3kc" />';
-  let twitterInsert = `\n    <meta name="twitter:title" content="${title}" />\n    <meta name="twitter:description" content="${description}" />`;
+  let twitterInsert = `\n    <meta name="twitter:title" content="${safeTitle}" />\n    <meta name="twitter:description" content="${safeDescription}" />`;
 
   // Add image tags if post has an image
   if (post.image) {


### PR DESCRIPTION
## Summary

- Add `scripts/generate-blog-meta.mjs` that runs after `vite build` to generate per-post `index.html` files with correct OpenGraph and Twitter Card meta tags (`og:title`, `og:description`, `og:url`, `og:type`, `og:image`, `twitter:title`, `twitter:description`)
- HTML-escape titles and descriptions to prevent malformed tags when posts contain `&`, `"`, `<`, or `>`
- Wire the script into `npm run build` via `package.json`

## Test plan

- [ ] `npm run build` succeeds without errors
- [ ] Inspect a generated `dist/blog/*/index.html` — confirm OG and Twitter meta tags are present and correctly populated
- [ ] Validate with LinkedIn Post Inspector or Facebook Sharing Debugger after deploy