### PR TITLE
feat: add Copy Markdown button to blog posts

### DIFF
--- a/src/components/blog/BlogPostPage.vue
+++ b/src/components/blog/BlogPostPage.vue
@@ -24,7 +24,7 @@ const post = computed(() => getPost(route.params.slug))
           <span v-if="post.updated" class="text-gray-400">(Updated: {{ post.updated }})</span>
           <span v-for="tag in post.tags" :key="tag" class="badge badge-outline badge-sm">{{ tag }}</span>
         </div>
-        <SocialShareButtons :title="post.title" :slug="post.slug" />
+        <SocialShareButtons :title="post.title" :slug="post.slug" :rawMarkdown="post.rawMarkdown" />
         <img v-if="post.image" :src="post.image" :alt="post.title" class="w-full rounded-lg my-4" />
         <div class="prose max-w-none">
           <component :is="post.component" />

--- a/src/components/blog/SocialShareButtons.vue
+++ b/src/components/blog/SocialShareButtons.vue
@@ -3,7 +3,8 @@ import { ref, computed } from 'vue'
 
 const props = defineProps({
   title: String,
-  slug: String
+  slug: String,
+  rawMarkdown: String
 })
 
 const copied = ref(false)
@@ -33,15 +34,23 @@ const shareLinks = computed(() => [
   }
 ])
 
+const copiedMarkdown = ref(false)
+
 async function copyLink() {
   await navigator.clipboard.writeText(url.value)
   copied.value = true
   setTimeout(() => { copied.value = false }, 2000)
 }
+
+async function copyMarkdown() {
+  await navigator.clipboard.writeText(props.rawMarkdown)
+  copiedMarkdown.value = true
+  setTimeout(() => { copiedMarkdown.value = false }, 2000)
+}
 </script>
 
 <template>
-  <div class="flex items-center gap-3 mb-6">
+  <div class="flex flex-wrap items-center gap-3 mb-6">
     <span class="text-sm text-gray-400">Share:</span>
     <a
       v-for="link in shareLinks"
@@ -62,5 +71,13 @@ async function copyLink() {
       <font-awesome-icon :icon="['fas', 'link']" class="text-xl" />
     </button>
     <span v-if="copied" class="text-sm text-success">Copied!</span>
+    <button
+      v-if="rawMarkdown"
+      @click="copyMarkdown"
+      class="btn btn-sm btn-outline btn-primary"
+    >
+      <font-awesome-icon :icon="['far', 'copy']" />
+      {{ copiedMarkdown ? 'Copied!' : 'Copy Markdown' }}
+    </button>
   </div>
 </template>

--- a/src/composables/useBlogPosts.js
+++ b/src/composables/useBlogPosts.js
@@ -1,4 +1,5 @@
 const modules = import.meta.glob('../content/blog/*.md', { eager: true })
+const rawModules = import.meta.glob('../content/blog/*.md', { query: '?raw', import: 'default', eager: true })
 
 function extractExcerpt(component) {
   // We'll use the first ~160 chars of the raw markdown body as excerpt
@@ -22,6 +23,7 @@ function getAllPosts() {
       status: mod.status || 'published',
       image: mod.image || '',
       component: mod.default,
+      rawMarkdown: rawModules[path] || '',
     }
   })
 


### PR DESCRIPTION
## Summary
- Add a "Copy Markdown" button to the blog post share bar so readers can copy raw Markdown source to clipboard
- Import raw Markdown via Vite's `?raw` query in `useBlogPosts.js` and pass it through `BlogPostPage.vue` as a prop
- Style the button as a labeled DaisyUI outline button (`btn btn-sm btn-outline btn-primary`), consistent with other site buttons
- Button text swaps to "Copied!" for 2 seconds after clicking

## Test plan
- [ ] Open a blog post and confirm the "Copy Markdown" button appears in the share bar
- [ ] Click the button — text should change to "Copied!" and clipboard should contain raw Markdown
- [ ] Verify existing share icons and copy-link button still work