### PR TITLE
fix: remove broken NotebookLM podcast links from pubs and news

### DIFF
--- a/public/files/news/2025-01-30.json
+++ b/public/files/news/2025-01-30.json
@@ -25,15 +25,6 @@
     },
     {
       "type": "string",
-      "msg": "or listen to the"
-    },
-    {
-      "type": "link",
-      "msg": "podcast",
-      "link": "https://notebooklm.google.com/notebook/33e368dc-92c1-4042-a6c5-3cb583c0e79a/audio"
-    },
-    {
-      "type": "string",
       "msg": "for details."
     }
   ]

--- a/public/files/news/2025-04-11.json
+++ b/public/files/news/2025-04-11.json
@@ -14,12 +14,6 @@
       "msg": "thread",
       "link": "https://x.com/Zening_Duan/status/1919538535977075008"
     },
-    { "type": "string", "msg": "or listen to the" },
-    {
-      "type": "link",
-      "msg": "podcast",
-      "link": "https://notebooklm.google.com/notebook/7ed2acbc-9a0d-44f9-8650-b309049d0408/audio"
-    },
     { "type": "string", "msg": "for details." }
   ]
 }

--- a/public/files/news/2025-05-15.json
+++ b/public/files/news/2025-05-15.json
@@ -25,15 +25,6 @@
     },
     {
       "type": "string",
-      "msg": "or listen to the"
-    },
-    {
-      "type": "link",
-      "msg": "podcast",
-      "link": "https://notebooklm.google.com/notebook/d33a3d4e-8124-4bfd-917f-f1af7425a1d1/audio"
-    },
-    {
-      "type": "string",
       "msg": "for details."
     }
   ]

--- a/public/files/news/2025-05-19.json
+++ b/public/files/news/2025-05-19.json
@@ -14,12 +14,6 @@
       "msg": "thread",
       "link": "https://x.com/yang3kc/status/1823404980126261262"
     },
-    { "type": "string", "msg": "or listen to the" },
-    {
-      "type": "link",
-      "msg": "podcast",
-      "link": "https://notebooklm.google.com/notebook/4b284bb8-a41c-49ce-afd0-574a2ff55dd9/audio"
-    },
     { "type": "string", "msg": "for details." },
     {
       "type": "string",

--- a/public/files/news/2025-07-09.json
+++ b/public/files/news/2025-07-09.json
@@ -12,16 +12,7 @@
     },
     {
       "type": "string",
-      "msg": "available. Listen to the"
-    },
-    {
-      "type": "link",
-      "msg": "podcast",
-      "link": "https://notebooklm.google.com/notebook/56698c30-b34f-4fd4-a1eb-e8a9a0b0cb39/audio"
-    },
-    {
-      "type": "string",
-      "msg": "for details."
+      "msg": "available."
     }
   ]
 }

--- a/public/files/news/2025-07-16.json
+++ b/public/files/news/2025-07-16.json
@@ -34,15 +34,6 @@
     },
     {
       "type": "string",
-      "msg": "or listen to the"
-    },
-    {
-      "type": "link",
-      "msg": "podcast",
-      "link": "https://notebooklm.google.com/notebook/e275fc3f-f98c-4596-b129-212205727fff/audio"
-    },
-    {
-      "type": "string",
       "msg": "for details."
     },
     {

--- a/public/files/pubs/duan2025constructing.json
+++ b/public/files/pubs/duan2025constructing.json
@@ -39,10 +39,6 @@
 		{
 			"name": "Twitter",
 			"url": "https://x.com/Zening_Duan/status/1919538535977075008"
-		},
-		{
-			"name": "Podcast",
-			"url": "https://notebooklm.google.com/notebook/7ed2acbc-9a0d-44f9-8650-b309049d0408/audio"
 		}
 	],
 	"altmetric": {

--- a/public/files/pubs/mimizuka2025post.json
+++ b/public/files/pubs/mimizuka2025post.json
@@ -27,10 +27,6 @@
     {
       "url": "https://x.com/yang3kc/status/1924466952753336703",
       "name": "Twitter"
-    },
-    {
-      "name": "Podcast",
-      "url": "https://notebooklm.google.com/notebook/d33a3d4e-8124-4bfd-917f-f1af7425a1d1/audio"
     }
   ],
   "altmetric": {

--- a/public/files/pubs/yan2025origin.json
+++ b/public/files/pubs/yan2025origin.json
@@ -22,10 +22,6 @@
     {
       "url": "https://x.com/yang3kc/status/1833149935807545378",
       "name": "Twitter"
-    },
-    {
-      "url": "https://notebooklm.google.com/notebook/33e368dc-92c1-4042-a6c5-3cb583c0e79a/audio",
-      "name": "Podcast"
     }
   ],
   "altmetric": {

--- a/public/files/pubs/yang2025accuracy.json
+++ b/public/files/pubs/yang2025accuracy.json
@@ -33,10 +33,6 @@
     {
       "url": "https://x.com/yang3kc/status/1823404980126261262",
       "name": "Twitter"
-    },
-    {
-      "url": "https://notebooklm.google.com/notebook/4b284bb8-a41c-49ce-afd0-574a2ff55dd9/audio",
-      "name": "Podcast"
     }
   ],
   "altmetric": {

--- a/public/files/pubs/yang2025domaindemo.json
+++ b/public/files/pubs/yang2025domaindemo.json
@@ -58,10 +58,6 @@
     {
       "url": "https://x.com/yang3kc/status/1880276838897045685",
       "name": "Twitter"
-    },
-    {
-      "url": "https://notebooklm.google.com/notebook/e275fc3f-f98c-4596-b129-212205727fff/audio",
-      "name": "Podcast"
     }
   ],
   "altmetric": {

--- a/public/files/pubs/yang2025news.json
+++ b/public/files/pubs/yang2025news.json
@@ -25,10 +25,6 @@
     {
       "url": "https://github.com/yang3kc/ai_search_arena",
       "name": "GitHub"
-    },
-    {
-      "url": "https://notebooklm.google.com/notebook/56698c30-b34f-4fd4-a1eb-e8a9a0b0cb39/audio",
-      "name": "Podcast"
     }
   ],
   "altmetric": {


### PR DESCRIPTION
Removes all dead NotebookLM podcast links from 6 publication entries and their corresponding 6 news entries. No source-code changes — data files only.