### PR TITLE
refactor: single source of truth for pub topic/type labels + data fixes

### DIFF
--- a/public/files/pubs/cresci2025demystifying.json
+++ b/public/files/pubs/cresci2025demystifying.json
@@ -28,7 +28,8 @@
     "journal"
   ],
   "topic": [
-    "bot"
+    "bot",
+    "socialmedia"
   ],
   "highlight": [],
   "links": [

--- a/public/files/pubs/mimizuka2025post.json
+++ b/public/files/pubs/mimizuka2025post.json
@@ -17,7 +17,7 @@
   "date": "2025-05-15",
   "year": [2026],
   "type": ["conference"],
-  "topic": ["social media"],
+  "topic": ["socialmedia"],
   "highlight": [],
   "links": [
     {

--- a/public/files/pubs/yang2026systematic.json
+++ b/public/files/pubs/yang2026systematic.json
@@ -11,7 +11,7 @@
   "date": "2026-04-21",
   "year": [2026],
   "type": ["preprint"],
-  "topic": ["social media", "method"],
+  "topic": ["socialmedia", "method"],
   "highlight": ["highlight"],
   "title": "A systematic review of social science studies analyzing social media data, 2010–2024",
   "links": [

--- a/src/components/pubs/PubsBlock.vue
+++ b/src/components/pubs/PubsBlock.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+import { labelFor } from '@/composables/usePubLabels';
 
 // props
 const props = defineProps({
@@ -85,6 +86,14 @@ onUnmounted(() => {
   <div class="text-center md:text-left">
     <!-- title -->
     <p><b>{{ pub_obj.bibtex.entryTags.title }}</b></p>
+    <!-- topic chips (pubs page only) -->
+    <div v-if="!is_home && pub_obj.topic && pub_obj.topic.length" class="flex flex-wrap gap-1 mt-1 mb-1">
+      <span
+        v-for="topic in pub_obj.topic"
+        :key="topic"
+        class="badge badge-outline badge-sm"
+      >{{ labelFor(topic) }}</span>
+    </div>
     <!-- authors  -->
     <p>
       🧑‍💻️

--- a/src/components/pubs/PubsList.vue
+++ b/src/components/pubs/PubsList.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, inject, onUpdated } from 'vue';
 import BackForth from '@/components/nav/BackForth.vue';
 import PubsBlock from '@/components/pubs/PubsBlock.vue';
+import { topicLabels, typeLabels } from '@/composables/usePubLabels';
 
 // props
 const props = defineProps({
@@ -14,19 +15,6 @@ const props = defineProps({
 // data
 const isHome = props.is_home;
 const topic_to_show = ref("all");
-const topic_dict = {
-  "all": {"name": " 🌐 All"},
-  "genai": {"name": "💡 Generative AI"},
-  "bot": {"name": "🤖 Social bot"},
-  "bias": {"name": "🔀 System bias"},
-  "misinformation": {"name": "📢 Misinformation"},
-  "netsci": {"name": "🕸 Network science"},
-  "opioid": { "name": "💊 Opioid crisis" }
-};
-const type_dict = {
-  "dataset": { "name": "💾 Dataset" },
-  "method": { "name": "🧪 Method" },
-}
 const highlight_dict = {
   "all": {"name": "✨ Highlight"},
   "recent": {"name": "📅 Recent"}
@@ -76,14 +64,15 @@ onUpdated(() => {
   <!-- Buttons for topic and type -->
   <div v-if="!isHome" class="flex flex-wrap justify-center gap-1">
     <p class="prose">Topic:</p>
-    <template v-for="topic in Object.keys(topic_dict)" :key="topic">
-      <button class="btn btn-sm btn-outline btn-primary" :class="{'btn-active': topic_to_show === topic}" @click="topic_to_show = topic" >{{ topic_dict[topic].name }}</button>
+    <button class="btn btn-sm btn-outline btn-primary" :class="{'btn-active': topic_to_show === 'all'}" @click="topic_to_show = 'all'">🌐 All</button>
+    <template v-for="(label, key) in topicLabels" :key="key">
+      <button class="btn btn-sm btn-outline btn-primary" :class="{'btn-active': topic_to_show === key}" @click="topic_to_show = key">{{ label }}</button>
     </template>
   </div>
   <div v-if="!isHome" class="flex flex-wrap justify-center gap-1 mt-2">
     <p class="prose">Type:</p>
-    <template v-for="type in Object.keys(type_dict)" :key="type">
-      <button class="btn btn-sm btn-outline btn-primary" :class="{'btn-active': topic_to_show === type}" @click="topic_to_show = type" >{{ type_dict[type].name }}</button>
+    <template v-for="(label, key) in typeLabels" :key="key">
+      <button class="btn btn-sm btn-outline btn-primary" :class="{'btn-active': topic_to_show === key}" @click="topic_to_show = key">{{ label }}</button>
     </template>
   </div>
   <hr class="col-span-full my-3">

--- a/src/composables/usePubLabels.js
+++ b/src/composables/usePubLabels.js
@@ -9,6 +9,7 @@ export const topicLabels = {
   netsci: "🕸 Network science",
   opioid: "💊 Opioid crisis",
   socialmedia: "📱 Social media",
+  covid: "🦠 COVID-19",
 };
 
 export const typeLabels = {

--- a/src/composables/usePubLabels.js
+++ b/src/composables/usePubLabels.js
@@ -1,0 +1,21 @@
+// src/composables/usePubLabels.js
+// Single source of truth for publication topic and type label mappings.
+
+export const topicLabels = {
+  genai: "💡 Generative AI",
+  bot: "🤖 Social bot",
+  bias: "🔀 System bias",
+  misinformation: "📢 Misinformation",
+  netsci: "🕸 Network science",
+  opioid: "💊 Opioid crisis",
+};
+
+export const typeLabels = {
+  dataset: "💾 Dataset",
+  method: "🧪 Method",
+};
+
+// Combined lookup for chips — falls back to the raw key when unknown.
+export function labelFor(key) {
+  return topicLabels[key] ?? typeLabels[key] ?? key;
+}

--- a/src/composables/usePubLabels.js
+++ b/src/composables/usePubLabels.js
@@ -8,6 +8,7 @@ export const topicLabels = {
   misinformation: "📢 Misinformation",
   netsci: "🕸 Network science",
   opioid: "💊 Opioid crisis",
+  socialmedia: "📱 Social media",
 };
 
 export const typeLabels = {


### PR DESCRIPTION
## Summary

- New `src/composables/usePubLabels.js` — single source of truth for topic/type label maps (`topicLabels`, `typeLabels`, `labelFor()`)
- `PubsList.vue` and `PubsBlock.vue` now import from the composable; inline dicts removed
- Chips for `dataset` (4 pubs) and `method` (11 pubs) now render as `💾 Dataset` / `🧪 Method` instead of raw strings
- Added `📱 Social media` and `🦠 COVID-19` labels
- Normalized `"social media"` → `"socialmedia"` in `mimizuka2025post.json` and `yang2026systematic.json`
- Added `socialmedia` topic to `cresci2025demystifying.json` (was the only bot paper missing it)