### PR TITLE
feat(media): add Brookings coverage of yang2025news

### DIFF
--- a/public/files/media.json
+++ b/public/files/media.json
@@ -1,5 +1,17 @@
 [
   {
+    "title": "Same gatekeepers, new tollbooths in the AI content licensing market",
+    "url": "https://www.brookings.edu/articles/same-gatekeepers-new-tollbooths-in-the-ai-content-licensing-market/",
+    "outlet": "Brookings",
+    "date": "2026-06-09",
+    "year": [2026],
+    "type": "coverage",
+    "topic": "ai",
+    "project_id": ["yang2025news"],
+    "toshow": true,
+    "highlight": false
+  },
+  {
     "title": "The Guardian view on the BBC's future: who decides what news means?",
     "url": "https://www.theguardian.com/commentisfree/2026/apr/01/the-guardian-view-on-the-bbcs-future-who-decides-what-news-means",
     "outlet": "The Guardian",


### PR DESCRIPTION
Adds Brookings article 'Same gatekeepers, new tollbooths in the AI content licensing market' (2026-06-09) as media coverage citing the yang2025news paper.