### PR TITLE
Site updates: news filter, workshop link, clickable pub chips

### DIFF
--- a/src/components/lab/LabIntro.vue
+++ b/src/components/lab/LabIntro.vue
@@ -18,6 +18,12 @@ const nav_links = [
         link: "/hiddencurriculum",
         is_internal: true,
     },
+    {
+        name: "Research with AI Agents Workshop",
+        emoji: "🤖",
+        link: "https://research-with-ai-agents-workshop.github.io/",
+        is_internal: false,
+    },
 ];
 </script>
 
@@ -52,7 +58,7 @@ const nav_links = [
                         class="link"
                         >{{ item.emoji }} {{ item.name }}</router-link
                     >
-                    <a v-else :href="item.link" class="link"
+                    <a v-else :href="item.link" class="link" target="_blank" rel="noopener noreferrer"
                         >{{ item.emoji }} {{ item.name }}</a
                     >
                     <span

--- a/src/components/news/NewsList.vue
+++ b/src/components/news/NewsList.vue
@@ -31,10 +31,13 @@ const news_to_show = computed(() => {
   if (props.is_home) {
     return news_list.value.slice(0, 5);
   } else {
+    const cutoff = new Date();
+    cutoff.setFullYear(cutoff.getFullYear() - 2);
+    const recent = news_list.value.filter(news => new Date(news.date) >= cutoff);
     if (type_to_show.value === "all") {
-      return news_list.value;
+      return recent;
     } else {
-      return news_list.value.filter(news => news.type === type_to_show.value);
+      return recent.filter(news => news.type === type_to_show.value);
     }
   }
 });

--- a/src/components/pubs/PubsBlock.vue
+++ b/src/components/pubs/PubsBlock.vue
@@ -16,6 +16,8 @@ const props = defineProps({
   }
 });
 
+const emit = defineEmits(['topic-click']);
+
 // data
 const show_modal = ref(null);
 const show_modal_type = ref(null);
@@ -91,7 +93,8 @@ onUnmounted(() => {
       <span
         v-for="topic in pub_obj.topic"
         :key="topic"
-        class="badge badge-outline badge-sm"
+        class="badge badge-outline badge-sm cursor-pointer hover:badge-primary hover:!text-white"
+        @click="emit('topic-click', topic)"
       >{{ labelFor(topic) }}</span>
     </div>
     <!-- authors  -->

--- a/src/components/pubs/PubsList.vue
+++ b/src/components/pubs/PubsList.vue
@@ -83,7 +83,7 @@ onUpdated(() => {
     </div>
     <!-- main info -->
     <div class="col-span-full md:col-span-5">
-      <PubsBlock :pub_obj="pub" :is_home="isHome"/>
+      <PubsBlock :pub_obj="pub" :is_home="isHome" @topic-click="topic_to_show = $event"/>
     </div>
     <!-- altmetric small -->
     <div class="col-span-full flex justify-center mt-2 md:hidden">


### PR DESCRIPTION
## Changes

### News page
- Filter to show only publications from the past two years (rolling cutoff); home page top-5 is unaffected.

### Home page
- Added 🤖 Research with AI Agents Workshop link to the "For students & researchers" row; opens in a new tab.

### Publications page
- Topic chips under each paper title are now clickable — clicking a chip filters the list to that topic (same as the top filter buttons) and highlights the active button.
- Chips show white text on red background on hover for readability.

## Testing
- Verified locally at http://localhost:5174/ with `npx vite`.